### PR TITLE
Pass exit code along from Sphinx Build

### DIFF
--- a/sphinx_pdf_generate/cli.py
+++ b/sphinx_pdf_generate/cli.py
@@ -155,6 +155,7 @@ def main() -> None:
             show(context=f"{pdf_generator.num_errors} conversion errors occurred (see above)", error=True)
     else:
         show(context="Sphinx build was unsuccessful. No PDF files were generated.", error=True)
+        raise SystemExit(builder)
 
 
 class PDFGenerateException(Exception):


### PR DESCRIPTION

## Proposed Change for issue #3

I suppose issue #3 was occurring because sphinx-pdf-generate is not passing along the exit code from sphinx-build, so I hope we could pass the exit code, such that the Github Action can be stopped on error. I made a small change, but I did not test it in Github Action, I think it should work, can you have a look?